### PR TITLE
Segregate even and odd nodes in a Link List

### DIFF
--- a/Segregate even and odd nodes in a Link List
+++ b/Segregate even and odd nodes in a Link List
@@ -1,0 +1,94 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+struct Node
+{
+    int data;
+    struct Node* next;
+
+    Node(int x){
+        data = x;
+        next = NULL;
+    }
+};
+void printList(Node* node) 
+{ 
+    while (node != NULL) { 
+        cout << node->data <<" "; 
+        node = node->next; 
+    }  
+    cout<<"\n";
+} 
+
+
+ // } Driver Code Ends
+//User function template for C++
+
+/*
+struct Node
+{
+    int data;
+    struct Node* next;
+
+    Node(int x){
+        data = x;
+        next = NULL;
+    }
+};
+*/
+class Solution{
+public:
+    Node* divide(int N, Node *head){
+        Node* even=new Node(0);
+        Node* odd=new Node(0);
+        Node* e=even;
+        Node* o=odd;
+        while(head!=NULL)
+        {
+            if(head->data%2==0)
+            {
+                e->next=head;
+                e=e->next;
+                head=head->next;
+            }
+            else
+            {
+                o->next=head;
+                o=o->next;
+                head=head->next;
+            }
+        }
+        o->next=NULL;
+        e->next=odd->next;
+        head=even->next;
+        return head;
+    }
+};
+
+// { Driver Code Starts.
+
+int main() {
+    //code
+    int t;
+    cin>>t;
+    while(t--){
+        int N;
+        cin>>N;
+        int data;
+        cin>>data;
+        struct Node *head = new Node(data);
+        struct Node *tail = head;
+        for (int i = 0; i < N-1; ++i)
+        {
+            cin>>data;
+            tail->next = new Node(data);
+            tail = tail->next;
+        }
+
+        Solution ob;
+        Node *ans = ob.divide(N, head);
+        printList(ans); 
+    }
+    return 0;
+}
+  // } Driver Code Ends


### PR DESCRIPTION
Given a link list of size N, modify the list such that all the even numbers appear before all the odd numbers in the modified list. The order of appearance of numbers within each segregation should be same as that in the original list.

NOTE: Don't create a new linked list, instead rearrange the provided one.


Example 1:

Input: 
N = 7
Link List:
17 -> 15 -> 8 -> 9 -> 2 -> 4 -> 6 -> NULL

Output: 8 2 4 6 17 15 9

Explaination: 8,2,4,6 are the even numbers 
so they appear first and 17,15,9 are odd 
numbers that appear later.